### PR TITLE
Refactor

### DIFF
--- a/chapeau.py
+++ b/chapeau.py
@@ -65,9 +65,8 @@ def render(clientsocket, path, params, header = None):
 
 
 def style_render(clientsocket, path):
-	message_file = open(path, 'r')
-	message_text = message_file.read()
-	message_file.close()
+	with open(path, 'r') as message_file:
+		message_text = message_file.read()
 	clientsocket.send('HTTP/1.0 200 OK\n\n')
 	clientsocket.send(message_text)
 	clientsocket.close()

--- a/chapeau.py
+++ b/chapeau.py
@@ -51,9 +51,8 @@ def post(clientsocket, request):
 
 # ----- sends http msg and page to client socket, then closes socket -----
 def render(clientsocket, path, params, header = None):
-	message_file = open(path, 'r')
-	message_text = message_file.read()
-	message_file.close()
+	with open(path, 'r') as message_file:
+		message_text = message_file.read()
 	new_msg = message_text % params
 	header_string = ''
 	if header != None:


### PR DESCRIPTION
I rewrote all occurrences of the `open(file)` -> `read()` -> `file.close()` code blocks to use the `with..as` context manager instead.  It helps make the code more idiomatic.